### PR TITLE
Update DsUtils.cs

### DIFF
--- a/src/ADCS.SidExtension.PolicyModule/DsUtils.cs
+++ b/src/ADCS.SidExtension.PolicyModule/DsUtils.cs
@@ -57,8 +57,19 @@ static class DsUtils {
 
         if (name.Contains("@")) {
             // upn
-            Int32 splitIndex = name.IndexOf("@", StringComparison.Ordinal);
-            domainTokens = name.Substring(splitIndex + 1).Split('.');
+            String domainPart = name.Substring(splitIndex + 1);
+            using (var forest = Forest.GetCurrentForest()) {
+                using (var domain = forest.Domains.FirstOrDefault(d => d.Forest.Name.Equals(domainPart, StringComparison.OrdinalIgnoreCase))) {
+                    if (domain != null)
+                    {
+                        domainTokens = domain.Name.Split('.');
+                    }
+                    else
+                    {
+                        domainTokens = null;
+                    }
+                }
+            }
         } else {
             // skip host part and return domain part
             domainTokens = name.Split('.').Skip(1).ToArray();

--- a/src/ADCS.SidExtension.PolicyModule/DsUtils.cs
+++ b/src/ADCS.SidExtension.PolicyModule/DsUtils.cs
@@ -67,7 +67,7 @@ static class DsUtils {
                     if (domain.GetDirectoryEntry().Properties["uPNSuffixes"].Contains(domainPart)) {
                         domainTokens = domain.Name.Split('.');
                     } else {
-                        domainTokens = null
+                        domainTokens = null;
                 }
             }
         } else {

--- a/src/ADCS.SidExtension.PolicyModule/DsUtils.cs
+++ b/src/ADCS.SidExtension.PolicyModule/DsUtils.cs
@@ -57,17 +57,17 @@ static class DsUtils {
 
         if (name.Contains("@")) {
             // upn
+            Int32 splitIndex = name.IndexOf("@", StringComparison.Ordinal);
+            //domainTokens = name.Substring(splitIndex + 1).Split('.');
             String domainPart = name.Substring(splitIndex + 1);
-            using (var forest = Forest.GetCurrentForest()) {
-                using (var domain = forest.Domains.FirstOrDefault(d => d.Forest.Name.Equals(domainPart, StringComparison.OrdinalIgnoreCase))) {
-                    if (domain != null)
-                    {
+            using (var forest = Forest.GetCurrentForest())
+            {
+                foreach (Domain domain in forest.Domains)
+                {
+                    if (domain.GetDirectoryEntry().Properties["uPNSuffixes"].Contains(domainPart)) {
                         domainTokens = domain.Name.Split('.');
-                    }
-                    else
-                    {
-                        domainTokens = null;
-                    }
+                    } else {
+                        domainTokens = null
                 }
             }
         } else {


### PR DESCRIPTION
Updated getDomainSearchRoot to handle alternate UPN suffixes for domain. 

When Global Catalog is not used and the user upn contains a domain that is an alternate UPN suffix, SID lookup fails.